### PR TITLE
added calc pipeline

### DIFF
--- a/data/dataset.ttl
+++ b/data/dataset.ttl
@@ -25,7 +25,8 @@
   rdfs:label "Costo dell'energia elettrica per comune"@it . 
 
 elcom-attr:year  a rdf:Property, qb:DimensionProperty;
-  rdfs:label "reference year"@en;
+  rdfs:label "Reference year"@en;
+  rdfs:label "Referenzjahr"@de;
   rdfs:subPropertyOf sdmx-dimension:refPeriod;
   scale:scaleOfMeasure scale:Temporal;
   rdfs:range xsd:gYear .
@@ -70,7 +71,7 @@ elcom-attr:fee  a rdf:Property, qb:MeasureProperty;
   rdfs:range xsd:decimal .
 
 elcom-attr:energy  a rdf:Property, qb:MeasureProperty;
-	rdfs:label "Engergy"@en;
+	rdfs:label "Energy"@en;
   rdfs:label "Energie"@de;
   rdfs:subPropertyOf sdmx-measure:obsValue;
   scale:scaleOfMeasure scale:Continuous;

--- a/data/dataset.ttl
+++ b/data/dataset.ttl
@@ -24,6 +24,12 @@
   rdfs:label "Prix du courant par commune"@fr ;
   rdfs:label "Costo dell'energia elettrica per comune"@it . 
 
+<http://elcom.zazuko.com/dataset/canton/medianElectricityTariffs> a qb:DataSet ;
+  rdfs:label "Median Strompreis per Kanton"@de ;
+  rdfs:label "Median electricity tariff per canton"@en ;
+  rdfs:label "Prix médian du courant par canton"@fr ;
+  rdfs:label "Costo medio dell'energia per cantone"@it . 
+
 elcom-attr:year  a rdf:Property, qb:DimensionProperty;
   rdfs:label "Reference year"@en;
   rdfs:label "Referenzjahr"@de;
@@ -49,9 +55,21 @@ elcom-attr:municipality a rdf:Property, qb:DimensionProperty;
   rdfs:label "Municipality"@en;
   scale:scaleOfMeasure scale:Nominal. 
 
+elcom-attr:canton a rdf:Property, qb:DimensionProperty;
+	rdfs:label "Kanton"@de;
+  rdfs:label "Canton"@en;
+  scale:scaleOfMeasure scale:Nominal. 
+
 elcom-attr:total a rdf:Property, qb:MeasureProperty;
 	rdfs:label "Total excl. VAT"@en;
   rdfs:label "Total exkl. MWST"@de;
+  rdfs:subPropertyOf sdmx-measure:obsValue;
+  scale:scaleOfMeasure scale:Continuous;
+  rdfs:range xsd:decimal .
+
+elcom-attr:totalMedian a rdf:Property, qb:MeasureProperty;
+	rdfs:label "Total median excl. VAT"@en;
+  rdfs:label "Total median exkl. MWST"@de;
   rdfs:subPropertyOf sdmx-measure:obsValue;
   scale:scaleOfMeasure scale:Continuous;
   rdfs:range xsd:decimal .

--- a/lib/calcSource.js
+++ b/lib/calcSource.js
@@ -1,0 +1,153 @@
+/*
+
+  TODO:
+    - some municipality URLs used in the tariff data can't be found in the geo.admin data
+    - some categories don't exist in all municipalities (canton population doesn't match population looping over tariff)
+
+ */
+
+const { readFile } = require('fs').promises
+const { resolve } = require('path')
+const { select } = require('barnard59-sparql')
+const getStream = require('get-stream')
+const namespace = require('@rdfjs/namespace')
+const rdf = require('rdf-ext')
+const { Readable } = require('readable-stream')
+
+const ns = {
+  elcomAttr: namespace('http://elcom.zazuko.com/attribute/'),
+  geonames: namespace('http://www.geonames.org/ontology#'),
+  xsd: namespace('http://www.w3.org/2001/XMLSchema#')
+}
+
+const municipalitiesQueryFilename = resolve(__dirname, '../sparql/municipalities.rq')
+const tariffQueryFilename = resolve(__dirname, '../sparql/tariff.rq')
+
+async function fetchMunicipalities ({ endpoint = 'https://ld.geo.admin.ch/query' } = {}) {
+  const query = (await readFile(municipalitiesQueryFilename)).toString()
+  const raw = await getStream.array(await select({ endpoint, query }))
+  const municipalities = new Map()
+
+  for (const row of raw) {
+    municipalities.set(row.municipality.value, {
+      name: row.name.value,
+      population: parseInt(row.population.value),
+      canton: row.canton.value
+    })
+  }
+
+  return municipalities
+}
+
+async function fetchTariff ({ endpoint, municipalities }) {
+  const query = (await readFile(tariffQueryFilename)).toString()
+  const raw = await getStream.array(await select({ endpoint, query }))
+
+  return raw.map(row => {
+    if (!municipalities.has(row.municipality.value)) {
+      // console.log(`municipality not found: ${row.municipality.value}`)
+    }
+
+    const municipality = municipalities.get(row.municipality.value) || {
+      name: '',
+      population: 0,
+      canton: ''
+    }
+
+    return {
+      canton: municipality.canton,
+      municipalityUrl: row.municipality.value,
+      municipalityName: municipality.name,
+      population: municipality.population,
+      category: row.category.value,
+      total: Math.round(parseFloat(row.total.value) * 100.0) / 100.0
+    }
+  }).sort((a, b) => {
+    const categoryCompare = a.category.localeCompare(b.category)
+    const cantonCompare = a.canton.localeCompare(b.canton)
+    const populationCompare = b.population - a.population
+
+    return categoryCompare|| cantonCompare || populationCompare
+  })
+}
+
+async function calc ({ tariffEndpoint }) {
+  const result = []
+  const municipalities = await fetchMunicipalities()
+  const tariff = await fetchTariff({ endpoint: tariffEndpoint, municipalities })
+
+  let done = false
+  let canton = null
+  let population = 0
+  let category = null
+  let populationTotal = 0
+  let populationMedian = 0
+
+  for (const row of tariff) {
+    if (row.category !== category || row.canton !== canton) {
+      done = false
+      canton = row.canton
+      category = row.category
+      population = 0
+      populationTotal = [...municipalities.values()].reduce((populationTotal, municipality) => {
+        if (municipality.canton !== canton) {
+          return populationTotal
+        }
+
+        return  populationTotal + municipality.population
+      }, 0)
+
+      populationMedian = Math.floor(populationTotal / 2 + 1)
+    }
+
+    population += row.population
+
+    if (!done && population > populationMedian) {
+      done = true
+
+      result.push({
+        canton,
+        category,
+        total: row.total
+      })
+    }
+  }
+
+  return result
+}
+
+class CalcStream extends Readable {
+  constructor ({ graph, tariffEndpoint }) {
+    super ({
+      objectMode: true,
+      read: () => {}
+    })
+
+    this.graph = graph === 'default' ? rdf.defaultGraph() : rdf.namedNode(graph)
+    this.tariffEndpoint = tariffEndpoint
+
+    this.calc()
+  }
+
+  async calc () {
+    const result = await calc({ tariffEndpoint: this.tariffEndpoint })
+
+    result.forEach(row => {
+      const cantonId = (row.canton.match(new RegExp('([0-9]*)\\:[0-9]{4}$')) || [])[1]
+      const categoryId = (row.category.match(new RegExp('([^/]*)$')) || [])[1]
+      const subject = rdf.namedNode(`http://elcom.zazuko.com/calc/${cantonId}/${categoryId}`)
+
+      this.push(rdf.quad(subject, ns.geonames.parentADM1, rdf.namedNode(row.canton), this.graph))
+      this.push(rdf.quad(subject, ns.elcomAttr.category, rdf.namedNode(row.category), this.graph))
+      this.push(rdf.quad(subject, ns.elcomAttr.totalMedian, rdf.literal(row.total, ns.xsd.double), this.graph))
+    })
+
+    this.push(null)
+  }
+
+  static create (options) {
+    return new CalcStream(options)
+  }
+}
+
+module.exports = CalcStream.create

--- a/lib/calcSource.js
+++ b/lib/calcSource.js
@@ -17,7 +17,9 @@ const { Readable } = require('readable-stream')
 const ns = {
   elcomAttr: namespace('http://elcom.zazuko.com/attribute/'),
   geonames: namespace('http://www.geonames.org/ontology#'),
-  xsd: namespace('http://www.w3.org/2001/XMLSchema#')
+  xsd: namespace('http://www.w3.org/2001/XMLSchema#'),
+  qb: namespace('http://purl.org/linked-data/cube#'),
+  rdf: namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#')
 }
 
 const municipalitiesQueryFilename = resolve(__dirname, '../sparql/municipalities.rq')
@@ -67,7 +69,7 @@ async function fetchTariff ({ endpoint, municipalities }) {
     const cantonCompare = a.canton.localeCompare(b.canton)
     const populationCompare = b.population - a.population
 
-    return categoryCompare|| cantonCompare || populationCompare
+    return categoryCompare || cantonCompare || populationCompare
   })
 }
 
@@ -94,7 +96,7 @@ async function calc ({ tariffEndpoint }) {
           return populationTotal
         }
 
-        return  populationTotal + municipality.population
+        return populationTotal + municipality.population
       }, 0)
 
       populationMedian = Math.floor(populationTotal / 2 + 1)
@@ -118,7 +120,7 @@ async function calc ({ tariffEndpoint }) {
 
 class CalcStream extends Readable {
   constructor ({ graph, tariffEndpoint }) {
-    super ({
+    super({
       objectMode: true,
       read: () => {}
     })
@@ -135,11 +137,13 @@ class CalcStream extends Readable {
     result.forEach(row => {
       const cantonId = (row.canton.match(new RegExp('([0-9]*)\\:[0-9]{4}$')) || [])[1]
       const categoryId = (row.category.match(new RegExp('([^/]*)$')) || [])[1]
-      const subject = rdf.namedNode(`http://elcom.zazuko.com/calc/${cantonId}/${categoryId}`)
+      const subject = rdf.namedNode(`http://elcom.zazuko.com/calc/observation/${cantonId}/${categoryId}`)
 
-      this.push(rdf.quad(subject, ns.geonames.parentADM1, rdf.namedNode(row.canton), this.graph))
+      this.push(rdf.quad(subject, ns.elcomAttr.canton, rdf.namedNode(row.canton), this.graph))
       this.push(rdf.quad(subject, ns.elcomAttr.category, rdf.namedNode(row.category), this.graph))
       this.push(rdf.quad(subject, ns.elcomAttr.totalMedian, rdf.literal(row.total, ns.xsd.double), this.graph))
+      this.push(rdf.quad(subject, ns.rdf.type, ns.qb.Observation, this.graph))
+      this.push(rdf.quad(subject, ns.qb.dataSet, rdf.namedNode('http://elcom.zazuko.com/dataset/canton/medianElectricityTariffs'), this.graph))
     })
 
     this.push(null)

--- a/package.json
+++ b/package.json
@@ -5,21 +5,27 @@
   "main": "index.js",
   "scripts": {
     "test": "standard && jest",
-    "start": "mkdir -p target source; barnard59 run --pipeline urn:pipeline:cube-ld#Root --format text/turtle pipelines/pipeline.ttl",
-    "provider": "mkdir -p target source; barnard59 run --pipeline urn:pipeline:provider/provider --format text/turtle pipelines/provider.ttl",
+    "postinstall": "mkdir -p target source",
+    "start": "barnard59 run --pipeline urn:pipeline:cube-ld#Root --format text/turtle pipelines/pipeline.ttl",
+    "provider": "barnard59 run --pipeline urn:pipeline:provider/provider --format text/turtle pipelines/provider.ttl",
+    "calc": "barnard59 run --pipeline https://linked.opendata.swiss/elcom/pipeline/calcFilePipeline --format text/turtle pipelines/calc.ttl",
     "pipeline": "npm start -- --pipeline"
   },
   "author": "Zazuko>",
   "license": "MIT",
   "bugs": {},
   "dependencies": {
+    "@rdfjs/namespace": "^1.1.0",
     "barnard59": "0.0.5",
     "barnard59-formats": "0.0.6",
     "barnard59-shell": "0.0.1",
+    "barnard59-sparql": "0.0.1",
     "barnard59-tdb": "git+https://github.com/zazuko/barnard59-tdb.git",
     "crc": "^3.8.0",
+    "get-stream": "^5.1.0",
     "node-fetch": "^2.6.0",
     "rdf-ext": "^1.3.0",
+    "readable-stream": "^3.4.0",
     "unzipper": "^0.9.11"
   },
   "devDependencies": {

--- a/pipelines/calc.ttl
+++ b/pipelines/calc.ttl
@@ -1,0 +1,67 @@
+@base <https://linked.opendata.swiss/elcom/pipeline/> .
+@prefix code: <https://code.described.at/> .
+@prefix p: <https://pipeline.described.at/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<variables>
+  p:variable [ a p:Variable;
+    p:name "tariffEndpoint";
+    p:value "https://trifid-lindas.test.cluster.ldbar.ch/query"
+  ], [ a p:Variable;
+    p:name "graph";
+    p:value "default"
+    # p:value "https://lindas-data.ch/graph/elcom/strompreise/calc"
+  ], [ a p:Variable;
+    p:name "outputFile";
+    p:value "target/calc.nq"
+  ].
+
+<calcPipeline> a p:Pipeline;
+  p:variables <variables>;
+  p:steps [
+    p:stepList ( <calc> <serialize> <upload> )
+  ].
+
+<calcFilePipeline> a p:Pipeline;
+  p:variables <variables>;
+  p:steps [
+    p:stepList ( <calc> <serialize> <writeFile> )
+  ].
+
+<calc> a p:Step;
+  code:implementedBy [ a code:EcmaScript;
+    code:link <file:../lib/calcSource.js>
+  ];
+  code:arguments [
+    code:name "graph";
+    code:value "graph"^^p:VariableName
+  ], [
+    code:name "tariffEndpoint";
+    code:value "tariffEndpoint"^^p:VariableName
+  ].
+
+<serialize> a p:Step;
+  code:implementedBy [ a code:EcmaScript;
+    code:link <node:barnard59-formats#ntriples.serialize>
+  ].
+
+<writeFile> a p:Step;
+  code:implementedBy [ a code:EcmaScript;
+    code:link <node:fs#createWriteStream>
+  ];
+  code:arguments ("outputFile"^^p:VariableName).
+
+<upload> a p:Step;
+  code:implementedBy [ a code:EcmaScript;
+    code:link <node:barnard59-graph-store#put>
+  ];
+  code:arguments [
+    code:name "endpoint";
+    code:value "endpoint"^^p:VariableName
+  ], [
+    code:name "user";
+    code:value "user"^^p:VariableName
+  ], [
+    code:name "password";
+    code:value "password"^^p:VariableName
+  ].

--- a/readme.md
+++ b/readme.md
@@ -1,66 +1,9 @@
-## blv-tierseuche pipelines
+## ElCom Strompreis pipelines
 
 To download and process entire dataset simply run:
 
 ```bash
-npm start
+npm run
 ```
 
-### Pipelines
-
-There a few pipelines in the definition. All of the share these parameters which can be
-overriden from command line
-
-| parameter | default value | description |
-| --- | --- | --- |
-| mappingsDir | metadata | directory containing the CSVW files |
-| sourceDir | source | location for extracted files |
-| targetDir | target | directory to write resulting n-triples  documents |
-| sourceUrl | http://ktk.netlabs.org/misc/rdf/seuchenmeldungen.zip ||
-
-Here's an example command for running with altered values
-
-```bash
-npm start -- --variable targetDir=processed
-```
-
-Note that the `--` are necessary with NPM.
-
-It is also possible to run the process partially. Do check below.
-
-#### Download only
-
-```
-npm run pipeline -- urn:pipeline:tierseuchen-ld#Download-Sources
-```
-
-Parameters:
-* `sourceUrl`
-* `sourceDir`
-
-#### Process previously downloaded files
-
-```
-npm run pipeline -- urn:pipeline:tierseuchen-ld#TransformFiles
-```
-
-Parameters:
-* `mappingsDir`
-* `targetDir`
-
-#### Process a single mapping
-
-```
-npm run pipeline -- urn:pipeline:tierseuchen-ld#TransformCsv --variable csvw=Stammdaten_tierart.csv.meta.json
-```
-
-Parameters:
-* `csvw` (mandatory)
-* `mappingsDir`
-* `targetDir`
-
-### CSVW mappings
-
-Mapping files are currently unaltered output of [`csvw-metadata.js`][meta-tool] tool.
-
-[meta-tool]: https://github.com/rdf-ext/rdf-parser-csvw/tree/develop/bin
+and choose one of the pipelines available.

--- a/sparql/municipalities.rq
+++ b/sparql/municipalities.rq
@@ -1,0 +1,20 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX schema: <http://schema.org/>
+PREFIX qb: <http://purl.org/linked-data/cube#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX elcom-attr: <http://elcom.zazuko.com/attribute/>
+PREFIX geonames: <http://www.geonames.org/ontology#>
+
+SELECT ?canton ?municipality ?population ?name WHERE {
+  ?version schema:validUntil "2019-12-31"^^xsd:date ;
+    geonames:parentADM1 ?canton ;
+    geonames:population ?population ;
+    schema:name ?name .
+
+  ?municipality dct:hasVersion ?version ;
+    geonames:featureCode geonames:A.ADM3 .
+} ORDER BY ?municipality

--- a/sparql/tariff.rq
+++ b/sparql/tariff.rq
@@ -1,0 +1,25 @@
+BASE <http://elcom.zazuko.com/calc/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX schema: <http://schema.org/>
+PREFIX qb: <http://purl.org/linked-data/cube#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX elcom-attr: <http://elcom.zazuko.com/attribute/>
+PREFIX geonames: <http://www.geonames.org/ontology#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+SELECT DISTINCT ?municipality ?category (AVG(?totalRaw) AS ?total) WHERE {
+  GRAPH <https://lindas-data.ch/graph/elcom/strompreise> {
+    ?provider schema:areaServed ?municipality ;
+      schema:name ?name .
+
+    ?obs elcom-attr:provider ?provider ;
+      elcom-attr:year "2020"^^xsd:gYear ;
+      elcom-attr:category ?category ;
+      elcom-attr:total ?totalRaw .
+
+  }
+} GROUP BY ?municipality ?category
+


### PR DESCRIPTION
This PR adds the pipeline to calculate the median values. The `calcSource.js` runs the SPARQL queries on the geo and bar endpoints, combines them, does the median calculation and returns the result as Quad Stream. Maybe the namespaces of the Quads need to be changed. The namespace factories are defined close to the top of the file, the quads almost at the end. The Turtle file for the pipelines contains already two pipelines, one to generate a file on the local file system, the other to use the Graph Store protocol to upload the data directly into the endpoint. The upload pipeline requires more variables, which are not yet prepared, cause it requires variables like user and password. A script was added to the `package.json` to run the file pipeline via npm.